### PR TITLE
fix: redirect /server/unti to quickstart/docker

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,6 +5,8 @@ import { usePathname } from 'next/navigation';
 
 // Mappings without /docs prefix - we normalize paths before matching
 const URL_MAPPINGS: Array<{ pattern: RegExp; replacement: string }> = [
+  // Broken link from Parseable UI (issue #1561)
+  { pattern: /^\/server\/unti/, replacement: '/quickstart/docker' },
   // Remove /server/ prefix (most common pattern from old docs)
   { pattern: /^\/server\/(.+)/, replacement: '/$1' },
   


### PR DESCRIPTION
## Summary
- Add explicit redirect mapping for `/server/unti` → `/quickstart/docker` in the 404 handler, placed before the generic `/server/(.+)` catch-all so the broken link from Parseable UI resolves correctly
- Remove the inert `redirect_from: /server/unti` entry from `content/docs/quickstart/docker.mdx` since the redirect generation script was removed in a prior commit

## Test plan
- [x] `npm run build` passes with no errors
- [ ] In dev mode, navigate to `/server/unti` and confirm the 404 page suggests `/quickstart/docker`
- [ ] On production, verify `https://www.parseable.com/docs/server/unti` redirects to the Docker quickstart page

🤖 Generated with [Claude Code](https://claude.com/claude-code)