### PR TITLE
Fix API auth and query docs

### DIFF
--- a/content/docs/api/index.mdx
+++ b/content/docs/api/index.mdx
@@ -55,11 +55,13 @@ Before you begin, make sure you have:
 
 ## Authentication
 
-All API requests require authentication. Include your API key in the `Authorization` header:
+API reference endpoints require authentication. The OpenAPI reference uses HTTP Basic authentication by default:
 
 ```bash
-Authorization: Bearer YOUR_API_KEY
+Authorization: Basic <base64-encoded-credentials>
 ```
+
+If you use Parseable API keys, send the key in the `X-API-Key` header as described in the [API Keys](/docs/user-guide/api-keys) guide.
 
 ## Rate Limiting
 

--- a/content/docs/api/v1/query.mdx
+++ b/content/docs/api/v1/query.mdx
@@ -14,8 +14,8 @@ _openapi:
 
           The query API accepts the following parameters:
           - **query**: The SQL query to execute (required)
-          - **startTime**: The start time for the query range (optional)
-          - **endTime**: The end time for the query range (optional)
+          - **startTime**: The start time for the query range (required)
+          - **endTime**: The end time for the query range (required)
           - **streamName**: The name of the log dataset to query (required)
 
           Example request body:
@@ -36,8 +36,8 @@ This endpoint allows you to query logs using PostgreSQL syntax.
 
 The query API accepts the following parameters:
 - **query**: The SQL query to execute (required)
-- **startTime**: The start time for the query range (optional)
-- **endTime**: The end time for the query range (optional)
+- **startTime**: The start time for the query range (required)
+- **endTime**: The end time for the query range (required)
 - **streamName**: The name of the log dataset to query (required)
 
 Example request body:

--- a/content/docs/self-hosted/metrics.mdx
+++ b/content/docs/self-hosted/metrics.mdx
@@ -7,7 +7,7 @@ redirect_from:
 ### Export Parseable to Prometheus
 Prometheus offers a multi-dimensional data model with time series data identified by metric name and key/value pairs. The data collection happens via a pull model over HTTP/HTTPS.
 
-Parseable server exposes Prometheus metrics at `/api/v1/metrics` endpoint (unauthorized). The metrics are exposed in Prometheus exposition format.
+Parseable server exposes Prometheus metrics at the `/api/v1/metrics` endpoint in Prometheus exposition format. If authentication is enabled for your Parseable instance, scrape the endpoint with valid Parseable credentials.
 
 ### Prerequisites
 Parseable server installed and running. See installation guide for more details.
@@ -33,9 +33,10 @@ Make sure to replace localhost:8000 with the actual host and port where Parseabl
 
 ### List of metrics exposed by Parseable
 
-Parseable server exposes the following metrics on `/api/v1/metrics` endpoint. All of these can be accessed via Prometheus dashboard. A sample list of exposed metrics along with their definition is available in the demo server at `https://demo.parseable.com/api/v1/metrics`.   
+Parseable server exposes the following metrics on the `/api/v1/metrics` endpoint. All of these can be accessed via Prometheus dashboard. A sample list of exposed metrics along with their definition is available in the demo server at `https://demo.parseable.com/api/v1/metrics`.
 
+For a local self-hosted instance, authenticate with your configured Parseable credentials:
 
 ```bash
-curl https://demo.parseable.com/api/v1/metrics
+curl -u admin:admin http://localhost:8000/api/v1/metrics
 ```

--- a/public/parseable-api-schema-cleaned.yaml
+++ b/public/parseable-api-schema-cleaned.yaml
@@ -118,8 +118,8 @@ paths:
         
         The query API accepts the following parameters:
         - **query**: The SQL query to execute (required)
-        - **startTime**: The start time for the query range (optional)
-        - **endTime**: The end time for the query range (optional)
+        - **startTime**: The start time for the query range (required)
+        - **endTime**: The end time for the query range (required)
         - **streamName**: The name of the log dataset to query (required)
         
         Example request body:
@@ -138,6 +138,8 @@ paths:
               type: object
               required:
                 - query
+                - startTime
+                - endTime
                 - streamName
               properties:
                 query:

--- a/public/parseable-api-schema.yaml
+++ b/public/parseable-api-schema.yaml
@@ -192,6 +192,11 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - query
+                - startTime
+                - endTime
+                - streamName
               properties:
                 query:
                   type: string


### PR DESCRIPTION
## Summary

- Clarify that `/api/v1/metrics` should be scraped with valid Parseable credentials when authentication is enabled.
- Mark `startTime` and `endTime` as required for `POST /api/v1/query` in the cleaned OpenAPI schema and generated query docs.
- Align the API overview authentication section with the OpenAPI Basic auth scheme and point API-key users to `X-API-Key`.

## Why

While setting up Parseable OSS v2.7.2, I hit two docs mismatches:

- `/api/v1/metrics` returned `401` without authentication and `200` with Basic auth, while the metrics docs described the endpoint as unauthenticated.
- `POST /api/v1/query` returned `400` with `Json deserialize error: missing field startTime` when `startTime`/`endTime` were omitted, while the generated API docs marked them optional.

The uncleaned OpenAPI schema already describes `startTime` and `endTime` as mandatory in prose; this change makes the schema-required fields and generated docs match that behavior.

## Validation

- `git diff --check`
- `npm run check-links` was run and still reports pre-existing unrelated broken links outside this change.
