### PR TITLE
  docs: document Helm OIDC configuration and S3 IRSA

### DIFF
--- a/content/docs/self-hosted/installation/distributed/k8s-helm-enterprise.mdx
+++ b/content/docs/self-hosted/installation/distributed/k8s-helm-enterprise.mdx
@@ -103,6 +103,12 @@ s3.region=<s3.region>
 EOF
 ```
 
+<Callout type="info">
+  Using Amazon EKS IRSA with Helm chart `3.0.1` or later? Omit `s3.access.key`
+  and `s3.secret.key` and configure the Parseable ServiceAccount instead. Follow the
+  [S3 IRSA guide](/docs/self-hosted/storage-targets/aws-s3#kubernetes-with-irsa).
+</Callout>
+
 Use `s3-store` in [`enterprise-values.yaml`](#7-create-enterprise-valuesyaml).
 
 ### Option C: Google Cloud Storage
@@ -274,6 +280,9 @@ parseable:
           cpu: "1"
           memory: 2Gi
 ```
+
+To enable OIDC, add the variables under `parseable.distributed.prism.env`. See
+the [OIDC guide](/docs/user-guide/openid).
 
 Before continuing:
 

--- a/content/docs/self-hosted/installation/distributed/k8s-helm-oss.mdx
+++ b/content/docs/self-hosted/installation/distributed/k8s-helm-oss.mdx
@@ -104,6 +104,12 @@ s3.region=<s3.region>
 EOF
 ```
 
+<Callout type="info">
+  Using Amazon EKS IRSA with Helm chart `3.0.1` or later? Omit `s3.access.key`
+  and `s3.secret.key` and configure the Parseable ServiceAccount instead. Follow the
+  [S3 IRSA guide](/docs/self-hosted/storage-targets/aws-s3#kubernetes-with-irsa).
+</Callout>
+
 Use `s3-store` in [`oss-values.yaml`](#6-create-oss-valuesyaml).
 
 ### Option C: Google Cloud Storage
@@ -234,6 +240,9 @@ parseable:
           accessMode: ReadWriteOnce
           size: 100Gi
 ```
+
+To enable OIDC, add the variables under
+`parseable.distributed.querier.env`. See the [OIDC guide](/docs/user-guide/openid).
 
 Before continuing:
 

--- a/content/docs/self-hosted/installation/standalone/aws-eks.mdx
+++ b/content/docs/self-hosted/installation/standalone/aws-eks.mdx
@@ -65,6 +65,6 @@ eksctl create iamserviceaccount --name my-service-account --namespace default --
 
 You can now refer to the standard Kubernetes documentation for Parseable installation, with Helm Chart or the Kubernetes Operator. Just ensure to use the service account you created above.
 
-If you're using Parseable Helm Chart, set `serviceAccount.create` to `false` and `serviceAccount.name` to the name of the service account you created above. For example `my-service-account`.
+If you're using Parseable Helm Chart `3.0.1` or later, set `parseable.serviceAccount.create` to `false` and `parseable.serviceAccount.name` to the name of the service account you created above. For example `my-service-account`. Omit `s3.access.key` and `s3.secret.key` from `parseable-env-secret`; see [Kubernetes with IRSA](/docs/self-hosted/storage-targets/aws-s3#kubernetes-with-irsa) for details.
 
 If you're using the Parseable Operator, set `serviceAccountName` under the `k8sConfig` section. Refer to a sample CR example [here](https://github.com/parseablehq/operator/blob/main/config/samples/parseable-persistent.yaml).

--- a/content/docs/self-hosted/installation/standalone/k8s-oss.mdx
+++ b/content/docs/self-hosted/installation/standalone/k8s-oss.mdx
@@ -116,6 +116,12 @@ s3.region=<s3.region>
 EOF
 ```
 
+<Callout type="info">
+  Using Amazon EKS IRSA with Helm chart `3.0.1` or later? Omit `s3.access.key`
+  and `s3.secret.key` and configure the Parseable ServiceAccount instead. Follow the
+  [S3 IRSA guide](/docs/self-hosted/storage-targets/aws-s3#kubernetes-with-irsa).
+</Callout>
+
 Use `s3-store` in [`standalone-values.yaml`](#6-create-standalone-valuesyaml).
 
 ### Option D: Google Cloud Storage
@@ -234,6 +240,9 @@ parseable:
           storageClass: <storage-class>
           size: 5Gi
 ```
+
+To enable OIDC, add the variables under `parseable.standalone.unified.env`. See
+the [OIDC guide](/docs/user-guide/openid).
 
 Before continuing:
 

--- a/content/docs/self-hosted/storage-targets/aws-s3.mdx
+++ b/content/docs/self-hosted/storage-targets/aws-s3.mdx
@@ -132,6 +132,18 @@ spec:
           args: ["parseable", "s3-store"]
 ```
 
+Before installing the Helm chart, follow the
+[AWS EKS guide](/docs/self-hosted/installation/standalone/aws-eks) to configure
+the IAM OIDC provider, IAM role, and Kubernetes ServiceAccount.
+
+With Helm chart `3.0.1` and later, omit `s3.access.key` and `s3.secret.key` from
+`parseable-env-secret`. Keep `s3.url`, `s3.bucket`, and `s3.region`.
+
+Earlier chart versions require both `s3.access.key` and `s3.secret.key`. Upgrade
+to chart `3.0.1` or later before using IRSA without static credentials. If you
+remain on an earlier chart version, keep both static credential keys in
+`parseable-env-secret`.
+
 ## S3 Bucket Configuration
 
 ### Bucket Policy (Optional)

--- a/content/docs/user-guide/openid.mdx
+++ b/content/docs/user-guide/openid.mdx
@@ -34,6 +34,70 @@ To use OIDC authentication with Parseable, you need to set the following environ
 | P_OIDC_ISSUER | Yes | The OIDC issuer URL, typically provided by your identity provider. It points to the OIDC authorization server. Should support discovery protocol | "" | "https://accounts.google.com" |
 | P_ORIGIN_URI | Yes | The URI where Parseable is hosted or accessible. This should be the base URL of your Parseable instance. | "" | "https://demo.parseable.com/" |
 
+## Kubernetes with Helm chart 3.0.0 and later
+
+Helm chart `3.0.0` and later configures environment variables per Parseable
+node. Add the OIDC variables to the node that serves the Console and login
+endpoints. The global `parseable.env` value used by chart `2.x` is no longer
+supported.
+
+Keep the values file containing `P_OIDC_CLIENT_SECRET` secure and do not commit
+it to source control.
+
+### Standalone OSS
+
+```yaml
+parseable:
+  standalone:
+    unified:
+      env:
+        P_OIDC_CLIENT_ID: "<client-id>"
+        P_OIDC_CLIENT_SECRET: "<client-secret>"
+        P_OIDC_ISSUER: "https://identity-provider.example.com"
+        P_ORIGIN_URI: "https://logs.example.com/"
+```
+
+### Distributed OSS
+
+The querier serves the Console and login endpoints:
+
+```yaml
+parseable:
+  distributed:
+    querier:
+      env:
+        P_OIDC_CLIENT_ID: "<client-id>"
+        P_OIDC_CLIENT_SECRET: "<client-secret>"
+        P_OIDC_ISSUER: "https://identity-provider.example.com"
+        P_ORIGIN_URI: "https://logs.example.com/"
+```
+
+### Distributed Enterprise
+
+Prism is the public entry point in an Enterprise deployment:
+
+```yaml
+parseable:
+  distributed:
+    prism:
+      env:
+        P_OIDC_CLIENT_ID: "<client-id>"
+        P_OIDC_CLIENT_SECRET: "<client-secret>"
+        P_OIDC_ISSUER: "https://identity-provider.example.com"
+        P_ORIGIN_URI: "https://logs.example.com/"
+```
+
+<Callout type="warning">
+  When upgrading from chart `2.x`, move the variables from `parseable.env` to
+  `parseable.standalone.unified.env`, `parseable.distributed.querier.env`, or
+  `parseable.distributed.prism.env`, depending on the deployment mode. Helm
+  does not migrate the old values automatically.
+</Callout>
+
+If a reverse proxy terminates TLS, configure it to preserve the original host
+and protocol headers. `P_ORIGIN_URI` must be the public HTTPS URL registered
+with the identity provider.
+
 ## Privilege Management with OIDC
 
 You can either setup a default OIDC role on Parseable instance or map a user group from your identity provider to a role on Parseable instance.


### PR DESCRIPTION
 ## Summary

  - document node-specific OIDC environment variable paths for Helm chart 3.x
  - add migration guidance from the chart 2.x `parseable.env` configuration
  - document reverse-proxy requirements for OIDC
  - document S3 authentication using EKS IRSA
  - clarify that IRSA without static S3 credentials requires Helm chart 3.0.1+
  - link installation guides to the OIDC and IRSA documentation